### PR TITLE
Added ability to switch the context you're viewing the documentation through (full framework vs libraries)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const output = `## Terraform Plan Output\n\`\`\`\n${{ steps.terraform-plan.outputs }}\n\`\`\``;
+            const output = `## Terraform Plan Output\n\`\`\`\n${{ steps.terraform-plan.outputs.output }}\n\`\`\``;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           terraform -chdir=./infrastructure/terraform init -backend-config="access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -backend-config="secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}"
           terraform -chdir=./infrastructure/terraform validate
-          output = terraform -chdir=./infrastructure/terraform plan -var="do_access_token=${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" -var="do_spaces_access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -var="do_spaces_secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}" -no-color -input=false
+          output=$(terraform -chdir=./infrastructure/terraform plan -var="do_access_token=${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" -var="do_spaces_access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -var="do_spaces_secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}" -no-color -input=false)
           echo "output=$output" >> $GITHUB_OUTPUT
         continue-on-error: true # We want the output even if this fails
       - name: Comment Terraform Plan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,9 @@ jobs:
           terraform -chdir=./infrastructure/terraform init -backend-config="access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -backend-config="secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}"
           terraform -chdir=./infrastructure/terraform validate
           output=$(terraform -chdir=./infrastructure/terraform plan -var="do_access_token=${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" -var="do_spaces_access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -var="do_spaces_secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}" -no-color -input=false)
-          echo "output=$output" >> $GITHUB_OUTPUT
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$output" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
         continue-on-error: true # We want the output even if this fails
       - name: Comment Terraform Plan
         uses: actions/github-script@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           terraform -chdir=./infrastructure/terraform init -backend-config="access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -backend-config="secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}"
           terraform -chdir=./infrastructure/terraform validate
-          terraform -chdir=./infrastructure/terraform plan -var="do_access_token=${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" -var="do_spaces_access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -var="do_spaces_secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}" -no-color -input=false
+          terraform -chdir=./infrastructure/terraform plan -var="do_access_token=${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" -var="do_spaces_access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -var="do_spaces_secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}" -no-color -input=false >> $GITHUB_OUTPUT
         continue-on-error: true # We want the output even if this fails
       - name: Comment Terraform Plan
         uses: actions/github-script@v7
@@ -81,7 +81,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const output = `## Terraform Plan Output\n\`\`\`\n${{ steps.terraform-plan.outputs.stdout }}\n\`\`\``;
+            const output = `## Terraform Plan Output\n\`\`\`\n${{ steps.terraform-plan.outputs }}\n\`\`\``;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           terraform -chdir=./infrastructure/terraform init -backend-config="access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -backend-config="secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}"
           terraform -chdir=./infrastructure/terraform validate
-          terraform -chdir=./infrastructure/terraform plan -var="do_access_token=${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" -var="do_spaces_access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -var="do_spaces_secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}" -no-color -input=false >> $GITHUB_OUTPUT
+          output = terraform -chdir=./infrastructure/terraform plan -var="do_access_token=${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" -var="do_spaces_access_key=${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}" -var="do_spaces_secret_key=${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}" -no-color -input=false
+          echo "output=$output" >> $GITHUB_OUTPUT
         continue-on-error: true # We want the output even if this fails
       - name: Comment Terraform Plan
         uses: actions/github-script@v7

--- a/README.md
+++ b/README.md
@@ -75,13 +75,15 @@ You must build your Docker images before you can run the application.  If using 
 eval $(minikube -p minikube docker-env)
 ```
 
-Then, build the images using your local Docker images:
+Build the Docker images:
 
 ```
 docker build -t aphiria.com-build -f ./infrastructure/docker/build/Dockerfile .
 docker build -t aphiria.com-api -f ./infrastructure/docker/runtime/api/Dockerfile . --build-arg BUILD_IMAGE=aphiria.com-build
 docker build -t aphiria.com-web -f ./infrastructure/docker/runtime/web/Dockerfile . --build-arg BUILD_IMAGE=aphiria.com-build
 ```
+
+> **Note:** To bust the Docker's cache, you should run `gulp build` locally prior to building the images to ensure you're building with the latest compiled documentation.
 
 ## Run The Application
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ You must build your Docker images before you can run the application.  If using 
 eval $(minikube -p minikube docker-env)
 ```
 
-Then, build the images:
+Then, build the images using your local Docker images:
 
 ```
 docker build -t aphiria.com-build -f ./infrastructure/docker/build/Dockerfile .
-docker build -t aphiria.com-api -f ./infrastructure/docker/runtime/api/Dockerfile .
-docker build -t aphiria.com-web -f ./infrastructure/docker/runtime/web/Dockerfile .
+docker build -t aphiria.com-api -f ./infrastructure/docker/runtime/api/Dockerfile . --build-arg BUILD_IMAGE=aphiria.com-build
+docker build -t aphiria.com-web -f ./infrastructure/docker/runtime/web/Dockerfile . --build-arg BUILD_IMAGE=aphiria.com-build
 ```
 
 ## Run The Application
@@ -120,3 +120,12 @@ kubectl apply -k ./infrastructure/kubernetes/environments/dev
 You should now be able to hit https://www.aphiria.com in your browser.  You will get a TLS certificate error since we're using a self-signed certificate locally.
 
 > **Note:** If using Chrome, type `thisisunsafe` to accept the self-signed certificate.  Likewise, you'll have to do the same for the API, which you can do by visiting https://api.aphiria.com/docs/search?query=foo and typing `thisisunsafe`.
+
+## Updating The Kubernetes Cluster
+
+To get your Minikube cluster to pick up changes you've made locally (after re-building the Docker images), run the following commands:
+
+```
+kubectl rollout restart deployment api
+kubectl rollout restart deployment web
+```

--- a/aphiria
+++ b/aphiria
@@ -34,7 +34,8 @@ if (!\class_exists($appBuilderClass) || !\is_subclass_of($appBuilderClass, IAppl
 }
 
 exit(
-    $container->resolve($appBuilderClass)
+    $container
+        ->resolve($appBuilderClass)
         ->withModule($globalModule)
         ->build()
         ->run()

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     },
     "require": {
         "aphiria/aphiria": "1.x-dev",
-        "erusev/parsedown-extra": "dev-master as 0.8.2",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
         "ext-pgsql": "*",
+        "league/commonmark": "^2.6",
         "league/flysystem": "^3.0",
         "php": ">=8.4",
         "symfony/dotenv": "^7.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "aphiria/aphiria": "1.x-dev",
-        "erusev/parsedown-extra": "^0.8",
+        "erusev/parsedown-extra": "dev-master as 0.8.2",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2bcd2801cff295ee1d26215c162744e",
+    "content-hash": "3572c8671641c1101366380cea2e2b35",
     "packages": [
         {
             "name": "aphiria/aphiria",
@@ -115,31 +115,38 @@
             "time": "2025-01-06T01:48:04+00:00"
         },
         {
-            "name": "erusev/parsedown",
-            "version": "dev-master",
+            "name": "dflydev/dot-access-data",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/erusev/parsedown.git",
-                "reference": "c9dc49f68f7bd14e5aa107d86a08ce59203f02ee"
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/c9dc49f68f7bd14e5aa107d86a08ce59203f02ee",
-                "reference": "c9dc49f68f7bd14e5aa107d86a08ce59203f02ee",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": ">=7.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5|^8.5|^9.6"
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.0.0"
             },
-            "default-branch": true,
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Parsedown": ""
+                "psr-4": {
+                    "Dflydev\\DotAccessData\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -148,78 +155,228 @@
             ],
             "authors": [
                 {
-                    "name": "Emanuil Rusev",
-                    "email": "hello@erusev.com",
-                    "homepage": "http://erusev.com"
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
                 }
             ],
-            "description": "Parser for Markdown.",
-            "homepage": "http://parsedown.org",
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
             "keywords": [
-                "markdown",
-                "parser"
+                "access",
+                "data",
+                "dot",
+                "notation"
             ],
             "support": {
-                "issues": "https://github.com/erusev/parsedown/issues",
-                "source": "https://github.com/erusev/parsedown/tree/master"
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
-            "time": "2024-12-01T16:36:17+00:00"
+            "time": "2024-07-08T12:26:09+00:00"
         },
         {
-            "name": "erusev/parsedown-extra",
-            "version": "dev-master",
+            "name": "league/commonmark",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/erusev/parsedown-extra.git",
-                "reference": "acebd175967ac1224dc710ab6082e5a28c202c85"
+                "url": "https://github.com/thephpleague/commonmark.git",
+                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown-extra/zipball/acebd175967ac1224dc710ab6082e5a28c202c85",
-                "reference": "acebd175967ac1224dc710ab6082e5a28c202c85",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d990688c91cedfb69753ffc2512727ec646df2ad",
+                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad",
                 "shasum": ""
             },
             "require": {
-                "erusev/parsedown": "dev-master",
-                "ext-dom": "*",
-                "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "php": ">=7.1"
+                "league/config": "^1.1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5|^8.5|^9.6"
+                "cebe/markdown": "^1.0",
+                "commonmark/cmark": "0.31.1",
+                "commonmark/commonmark.js": "0.31.1",
+                "composer/package-versions-deprecated": "^1.8",
+                "embed/embed": "^4.4",
+                "erusev/parsedown": "^1.0",
+                "ext-json": "*",
+                "github/gfm": "0.29.0",
+                "michelf/php-markdown": "^1.4 || ^2.0",
+                "nyholm/psr7": "^1.5",
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "scrutinizer/ocular": "^1.8.1",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "unleashedtech/php-coding-standard": "^3.1.1",
+                "vimeo/psalm": "^4.24.0 || ^5.0.0"
             },
-            "default-branch": true,
+            "suggest": {
+                "symfony/yaml": "v2.3+ required if using the Front Matter extension"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.7-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "ParsedownExtra": ""
+                "psr-4": {
+                    "League\\CommonMark\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Emanuil Rusev",
-                    "email": "hello@erusev.com",
-                    "homepage": "https://erusev.com"
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
                 }
             ],
-            "description": "An extension of Parsedown that adds support for Markdown Extra.",
-            "homepage": "https://github.com/erusev/parsedown-extra",
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and GitHub-Flavored Markdown (GFM)",
+            "homepage": "https://commonmark.thephpleague.com",
             "keywords": [
+                "commonmark",
+                "flavored",
+                "gfm",
+                "github",
+                "github-flavored",
                 "markdown",
-                "markdown extra",
-                "parsedown",
+                "md",
                 "parser"
             ],
             "support": {
-                "issues": "https://github.com/erusev/parsedown-extra/issues",
-                "source": "https://github.com/erusev/parsedown-extra/tree/master"
+                "docs": "https://commonmark.thephpleague.com/",
+                "forum": "https://github.com/thephpleague/commonmark/discussions",
+                "issues": "https://github.com/thephpleague/commonmark/issues",
+                "rss": "https://github.com/thephpleague/commonmark/releases.atom",
+                "source": "https://github.com/thephpleague/commonmark"
             },
-            "time": "2024-11-03T08:25:00+00:00"
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-29T14:10:59+00:00"
+        },
+        {
+            "name": "league/config",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/config.git",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3.0.1",
+                "nette/schema": "^1.2",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Define configuration arrays with strict schemas and access values with dot notation",
+            "homepage": "https://config.thephpleague.com",
+            "keywords": [
+                "array",
+                "config",
+                "configuration",
+                "dot",
+                "dot-access",
+                "nested",
+                "schema"
+            ],
+            "support": {
+                "docs": "https://config.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/config/issues",
+                "rss": "https://github.com/thephpleague/config/releases.atom",
+                "source": "https://github.com/thephpleague/config"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-11T20:36:23+00:00"
         },
         {
             "name": "league/flysystem",
@@ -512,6 +669,154 @@
             "time": "2024-11-12T12:43:37+00:00"
         },
         {
+            "name": "nette/schema",
+            "version": "v1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "da801d52f0354f70a638673c4a0f04e16529431d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/da801d52f0354f70a638673c4a0f04e16529431d",
+                "reference": "da801d52f0354f70a638673c4a0f04e16529431d",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.4"
+            },
+            "require-dev": {
+                "nette/tester": "^2.5.2",
+                "phpstan/phpstan-nette": "^1.0",
+                "tracy/tracy": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.3.2"
+            },
+            "time": "2024-10-06T23:10:23+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.0 - 8.4"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "dev-master",
+                "nette/tester": "^2.5",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.0.5"
+            },
+            "time": "2024-08-07T15:39:19+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "2.0.2",
             "source": {
@@ -563,6 +868,56 @@
                 "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
             "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1164,6 +1519,86 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2675,16 +3110,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.67.1",
+            "version": "v3.68.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "db533e9aeb19c33033b6a1b734c8de4f4ebaa7dc"
+                "reference": "73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/db533e9aeb19c33033b6a1b734c8de4f4ebaa7dc",
-                "reference": "db533e9aeb19c33033b6a1b734c8de4f4ebaa7dc",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c",
+                "reference": "73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c",
                 "shasum": ""
             },
             "require": {
@@ -2766,7 +3201,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.67.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.68.0"
             },
             "funding": [
                 {
@@ -2774,7 +3209,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-12T12:20:47+00:00"
+            "time": "2025-01-13T17:01:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3610,16 +4045,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.2",
+            "version": "11.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "153d0531b9f7e883c5053160cad6dd5ac28140b3"
+                "reference": "30e319e578a7b5da3543073e30002bf82042f701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/153d0531b9f7e883c5053160cad6dd5ac28140b3",
-                "reference": "153d0531b9f7e883c5053160cad6dd5ac28140b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/30e319e578a7b5da3543073e30002bf82042f701",
+                "reference": "30e319e578a7b5da3543073e30002bf82042f701",
                 "shasum": ""
             },
             "require": {
@@ -3640,7 +4075,7 @@
                 "phpunit/php-timer": "^7.0.1",
                 "sebastian/cli-parser": "^3.0.2",
                 "sebastian/code-unit": "^3.0.2",
-                "sebastian/comparator": "^6.2.1",
+                "sebastian/comparator": "^6.3.0",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.0",
                 "sebastian/exporter": "^6.3.0",
@@ -3691,7 +4126,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.3"
             },
             "funding": [
                 {
@@ -3707,57 +4142,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-21T05:51:08+00:00"
-        },
-        {
-            "name": "psr/event-dispatcher",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/event-dispatcher.git",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\EventDispatcher\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Standard interfaces for event handling.",
-            "keywords": [
-                "events",
-                "psr",
-                "psr-14"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/event-dispatcher/issues",
-                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
-            },
-            "time": "2019-01-08T18:20:26+00:00"
+            "time": "2025-01-13T09:36:00+00:00"
         },
         {
             "name": "react/cache",
@@ -5850,86 +6235,6 @@
             "time": "2024-11-20T11:17:29+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
             "name": "symfony/polyfill-php81",
             "version": "v1.31.0",
             "source": {
@@ -6429,18 +6734,10 @@
             "time": "2022-06-03T18:03:27+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "erusev/parsedown-extra",
-            "version": "9999999-dev",
-            "alias": "0.8.2",
-            "alias_normalized": "0.8.2.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
         "aphiria/aphiria": 20,
-        "erusev/parsedown-extra": 20,
         "phpunit/phpunit": 20,
         "vimeo/psalm": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce63849b0854dfa373bb2c9196049051",
+    "content-hash": "b2bcd2801cff295ee1d26215c162744e",
     "packages": [
         {
             "name": "aphiria/aphiria",
@@ -116,25 +116,26 @@
         },
         {
             "name": "erusev/parsedown",
-            "version": "1.7.4",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+                "reference": "c9dc49f68f7bd14e5aa107d86a08ce59203f02ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/c9dc49f68f7bd14e5aa107d86a08ce59203f02ee",
+                "reference": "c9dc49f68f7bd14e5aa107d86a08ce59203f02ee",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=5.3.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35"
+                "phpunit/phpunit": "^7.5|^8.5|^9.6"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -160,30 +161,35 @@
             ],
             "support": {
                 "issues": "https://github.com/erusev/parsedown/issues",
-                "source": "https://github.com/erusev/parsedown/tree/1.7.x"
+                "source": "https://github.com/erusev/parsedown/tree/master"
             },
-            "time": "2019-12-30T22:54:17+00:00"
+            "time": "2024-12-01T16:36:17+00:00"
         },
         {
             "name": "erusev/parsedown-extra",
-            "version": "0.8.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown-extra.git",
-                "reference": "91ac3ff98f0cea243bdccc688df43810f044dcef"
+                "reference": "acebd175967ac1224dc710ab6082e5a28c202c85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown-extra/zipball/91ac3ff98f0cea243bdccc688df43810f044dcef",
-                "reference": "91ac3ff98f0cea243bdccc688df43810f044dcef",
+                "url": "https://api.github.com/repos/erusev/parsedown-extra/zipball/acebd175967ac1224dc710ab6082e5a28c202c85",
+                "reference": "acebd175967ac1224dc710ab6082e5a28c202c85",
                 "shasum": ""
             },
             "require": {
-                "erusev/parsedown": "^1.7.4"
+                "erusev/parsedown": "dev-master",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35"
+                "phpunit/phpunit": "^7.5|^8.5|^9.6"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -198,7 +204,7 @@
                 {
                     "name": "Emanuil Rusev",
                     "email": "hello@erusev.com",
-                    "homepage": "http://erusev.com"
+                    "homepage": "https://erusev.com"
                 }
             ],
             "description": "An extension of Parsedown that adds support for Markdown Extra.",
@@ -211,9 +217,9 @@
             ],
             "support": {
                 "issues": "https://github.com/erusev/parsedown-extra/issues",
-                "source": "https://github.com/erusev/parsedown-extra/tree/0.8.x"
+                "source": "https://github.com/erusev/parsedown-extra/tree/master"
             },
-            "time": "2019-12-30T23:20:37+00:00"
+            "time": "2024-11-03T08:25:00+00:00"
         },
         {
             "name": "league/flysystem",
@@ -2669,16 +2675,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.66.1",
+            "version": "v3.67.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "cde186799d8e92960c5a00c96e6214bf7f5547a9"
+                "reference": "db533e9aeb19c33033b6a1b734c8de4f4ebaa7dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/cde186799d8e92960c5a00c96e6214bf7f5547a9",
-                "reference": "cde186799d8e92960c5a00c96e6214bf7f5547a9",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/db533e9aeb19c33033b6a1b734c8de4f4ebaa7dc",
+                "reference": "db533e9aeb19c33033b6a1b734c8de4f4ebaa7dc",
                 "shasum": ""
             },
             "require": {
@@ -2760,7 +2766,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.66.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.67.1"
             },
             "funding": [
                 {
@@ -2768,7 +2774,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-05T14:43:25+00:00"
+            "time": "2025-01-12T12:20:47+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4523,16 +4529,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.2.1",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "43d129d6a0f81c78bee378b46688293eb7ea3739"
+                "reference": "d4e47a769525c4dd38cea90e5dcd435ddbbc7115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/43d129d6a0f81c78bee378b46688293eb7ea3739",
-                "reference": "43d129d6a0f81c78bee378b46688293eb7ea3739",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/d4e47a769525c4dd38cea90e5dcd435ddbbc7115",
+                "reference": "d4e47a769525c4dd38cea90e5dcd435ddbbc7115",
                 "shasum": ""
             },
             "require": {
@@ -4544,6 +4550,9 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
@@ -4588,7 +4597,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.2.1"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.0"
             },
             "funding": [
                 {
@@ -4596,7 +4605,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-31T05:30:08+00:00"
+            "time": "2025-01-06T10:28:19+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -6420,10 +6429,18 @@
             "time": "2022-06-03T18:03:27+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "erusev/parsedown-extra",
+            "version": "9999999-dev",
+            "alias": "0.8.2",
+            "alias_normalized": "0.8.2.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
         "aphiria/aphiria": 20,
+        "erusev/parsedown-extra": 20,
         "phpunit/phpunit": 20,
         "vimeo/psalm": 20
     },

--- a/infrastructure/docker/build/Dockerfile
+++ b/infrastructure/docker/build/Dockerfile
@@ -1,7 +1,5 @@
 FROM php:8.4.1-fpm
 
-MAINTAINER David Young
-
 WORKDIR /app
 
 # Install dependencies and extensions

--- a/infrastructure/docker/build/Dockerfile
+++ b/infrastructure/docker/build/Dockerfile
@@ -19,4 +19,3 @@ RUN yarn install && yarn global add gulp
 # Use the docs' git SHA to bust the cache and force gulp build to run when it has changed
 ARG DOCS_SHA=latest
 RUN gulp build
-

--- a/infrastructure/docker/runtime/api/Dockerfile
+++ b/infrastructure/docker/runtime/api/Dockerfile
@@ -1,6 +1,7 @@
 # Stage 1: Use the build image to copy necessary files
+ARG BUILD_IMAGE=davidbyoung/aphiria.com-build
 ARG IMAGE_SHA=latest
-FROM davidbyoung/aphiria.com-build:${IMAGE_SHA} AS build
+FROM ${BUILD_IMAGE}:${IMAGE_SHA} AS build
 
 # Stage 2: Base PHP image for the final container
 FROM php:8.4.1-fpm AS base

--- a/infrastructure/docker/runtime/web/Dockerfile
+++ b/infrastructure/docker/runtime/web/Dockerfile
@@ -1,6 +1,7 @@
-# Stage 1: Build image
+# Stage 1: Use the build image to copy necessary files
+ARG BUILD_IMAGE=davidbyoung/aphiria.com-build
 ARG IMAGE_SHA=latest
-FROM davidbyoung/aphiria.com-build:${IMAGE_SHA} AS build
+FROM ${BUILD_IMAGE}:${IMAGE_SHA} AS build
 
 # Stage 2: Nginx image for serving content
 FROM nginx:alpine

--- a/infrastructure/kubernetes/base/gateway-api/gateway.yml
+++ b/infrastructure/kubernetes/base/gateway-api/gateway.yml
@@ -33,7 +33,7 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
-          - name: tls-cert
+          - name: tls-secret
     - name: https-subdomains
       hostname: "*.aphiria.com"
       port: 443
@@ -44,4 +44,4 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
-          - name: tls-cert
+          - name: tls-secret

--- a/resources/css/aphiria.css
+++ b/resources/css/aphiria.css
@@ -260,7 +260,7 @@ p code, li code {
 
 p code {
   border: 1px solid #e9e9e9 !important;
-  white-space: pre !important; }
+  white-space: pre-wrap !important; }
 
 body.home > main h1, body.home > main h2, body.home > main pre.center {
   text-align: center; }

--- a/resources/css/aphiria.scss
+++ b/resources/css/aphiria.scss
@@ -385,7 +385,7 @@ p code, li code {
 
 p code {
     border: 1px solid #e9e9e9 !important;
-    white-space: pre !important;
+    white-space: pre-wrap !important;
 }
 
 body.home > main {

--- a/resources/css/prism.css
+++ b/resources/css/prism.css
@@ -17,7 +17,7 @@ pre[class*="language-"] {
     white-space: pre;
     word-spacing: normal;
     word-break: normal;
-    word-wrap: normal;
+    word-wrap: break-word;
     line-height: 1.5;
 
     -moz-tab-size: 4;

--- a/resources/js/aphiria.js
+++ b/resources/js/aphiria.js
@@ -113,7 +113,10 @@ window.addEventListener('load', loadEvent => {
         } else if (searchInputElem.value !== prevSearchQuery) {
             timer = setTimeout(() => {
                 prevSearchQuery = searchInputElem.value;
-                fetch(`${config.apiUri}/docs/search?query=${encodeURIComponent(searchInputElem.value)}`)
+                fetch(
+                    `${config.apiUri}/docs/search?query=${encodeURIComponent(searchInputElem.value)}`,
+                    { credentials: 'include' }
+                )
                     .then((response) => response.json())
                     .then(searchResults => {
                         let searchResultItems = '';

--- a/resources/views/doc.html
+++ b/resources/views/doc.html
@@ -60,13 +60,6 @@
             {{ mainNav }}
         </header>
         <main>
-            <label title="Choose the context to view the documentation with">
-                Context:
-                <select id="context-selector">
-                    <option value="framework">Framework</option>
-                    <option value="library">Library</option>
-                </select>
-            </label>
             {{ sideNav }}
             <article>
                 {{ doc }}

--- a/resources/views/doc.html
+++ b/resources/views/doc.html
@@ -3,9 +3,67 @@
     <head>
         <title>{{ docTitle }} | Aphiria</title>
         {{ head }}
+        <style>
+            .context-framework, .context-library {
+                display: none;
+            }
+        </style>
+        <script>
+            function setCookie(name, value, days) {
+                const date = new Date();
+                date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+                document.cookie = `${name}=${value};expires=${date.toUTCString()};path=/`;
+            }
+
+            function getCookie(name) {
+                const cookies = document.cookie.split(';');
+
+                for (const cookie of cookies) {
+                    const [key, value] = cookie.trim().split('=');
+                    if (key === name) return value;
+                }
+
+                return null;
+            }
+
+            function toggleContext(view) {
+                const frameworkDivs = document.querySelectorAll('.context-framework');
+                const libraryDivs = document.querySelectorAll('.context-library');
+
+                if (view === 'framework') {
+                    frameworkDivs.forEach(div => div.style.display = 'block');
+                    libraryDivs.forEach(div => div.style.display = 'none');
+                } else if (view === 'library') {
+                    frameworkDivs.forEach(div => div.style.display = 'none');
+                    libraryDivs.forEach(div => div.style.display = 'block');
+                }
+            }
+
+            document.addEventListener('DOMContentLoaded', () => {
+                const contextSelector = document.getElementById('context-selector');
+                const savedContext = getCookie('context') || 'framework';
+
+                contextSelector.value = savedContext;
+                toggleContext(savedContext);
+
+                // Add event listener to update the view and cookie on selection
+                contextSelector.addEventListener('change', (event) => {
+                    const selectedContext = event.target.value;
+                    setCookie('context', selectedContext, 365);
+                    toggleContext(selectedContext);
+                });
+            });
+        </script>
     </head>
     <body class="docs language-php">
         <header>
+            <label title="Choose the context to view the documentation with">
+                Context:
+                <select id="context-selector">
+                    <option value="framework">Framework</option>
+                    <option value="library">Library</option>
+                </select>
+            </label>
             {{ mainNav }}
         </header>
         <main>

--- a/resources/views/doc.html
+++ b/resources/views/doc.html
@@ -57,6 +57,9 @@
     </head>
     <body class="docs language-php">
         <header>
+            {{ mainNav }}
+        </header>
+        <main>
             <label title="Choose the context to view the documentation with">
                 Context:
                 <select id="context-selector">
@@ -64,9 +67,6 @@
                     <option value="library">Library</option>
                 </select>
             </label>
-            {{ mainNav }}
-        </header>
-        <main>
             {{ sideNav }}
             <article>
                 {{ doc }}

--- a/resources/views/doc.html
+++ b/resources/views/doc.html
@@ -12,7 +12,7 @@
             function setCookie(name, value, days) {
                 const date = new Date();
                 date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-                document.cookie = `${name}=${value};expires=${date.toUTCString()};path=/`;
+                document.cookie = `${name}=${value};expires=${date.toUTCString()};path=/;domain=.aphiria.com;Secure;SameSite=Lax`;
             }
 
             function getCookie(name) {

--- a/resources/views/partials/head.html
+++ b/resources/views/partials/head.html
@@ -1,4 +1,4 @@
-<meta name="viewport" content="initial-scale=1" />
+<meta name="viewport" content="initial-scale=1">
         <!-- Favicons -->
         <link rel="shortcut icon" href="/images/favicon/favicon.ico">
         <link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-touch-icon.png">

--- a/resources/views/partials/side-nav.html
+++ b/resources/views/partials/side-nav.html
@@ -1,3 +1,10 @@
 <nav class="side-nav">
+    <label title="Choose the context to view the documentation with">
+        Context:
+        <select id="context-selector">
+            <option value="framework">Framework</option>
+            <option value="library">Library</option>
+        </select>
+    </label>
     {{ contents }}
 </nav>

--- a/src/Documentation/Api/Controllers/DocumentationController.php
+++ b/src/Documentation/Api/Controllers/DocumentationController.php
@@ -51,8 +51,7 @@ final class DocumentationController extends BaseController
         }
 
         $context = match ($rawContext) {
-            null => Context::Global,
-            'framework' => Context::Framework,
+            null, 'framework' => Context::Framework,
             'library' => Context::Library,
             default => throw new InvalidContextException('Context must be either "framework" or "library"')
         };

--- a/src/Documentation/Api/Controllers/DocumentationController.php
+++ b/src/Documentation/Api/Controllers/DocumentationController.php
@@ -17,6 +17,8 @@ use Aphiria\Routing\Attributes\Controller;
 use Aphiria\Routing\Attributes\Get;
 use Aphiria\Routing\Attributes\QueryString;
 use App\Documentation\DocumentationIndexer;
+use App\Documentation\Searching\Context;
+use App\Documentation\Searching\InvalidContextException;
 use App\Documentation\Searching\SearchResult;
 
 /**
@@ -35,10 +37,26 @@ final class DocumentationController extends BaseController
      *
      * @param string $query The search query
      * @return list<SearchResult> The list of search results
+     * @throws InvalidContextException Thrown if the context was invalid
      */
     #[Get('search')]
     public function searchDocs(#[QueryString] string $query): array
     {
-        return $this->docs->searchDocs($query);
+        $cookies = $this->requestParser->parseCookies($this->request);
+
+        if ($cookies->containsKey('context')) {
+            $rawContext = $cookies->get('context');
+        } else {
+            $rawContext = null;
+        }
+
+        $context = match ($rawContext) {
+            null => Context::Global,
+            'framework' => Context::Framework,
+            'library' => Context::Library,
+            default => throw new InvalidContextException('Context must be either "framework" or "library"')
+        };
+
+        return $this->docs->searchDocs($query, $context);
     }
 }

--- a/src/Documentation/Binders/DocumentationBinder.php
+++ b/src/Documentation/Binders/DocumentationBinder.php
@@ -21,8 +21,7 @@ use App\Documentation\Searching\PostgreSqlSearchIndex;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\DisallowedRawHtml\DisallowedRawHtmlExtension;
-use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
-use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
+use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
@@ -64,9 +63,24 @@ final class DocumentationBinder extends Binder
         );
         $container->bindInstance(FilesystemOperator::class, $files);
 
-        $environment = new Environment();
+        $config = [
+            'table' => [
+                'wrap' => [
+                    'enabled' => false,
+                    'tag' => 'div',
+                    'attributes' => [],
+                ],
+                'alignment_attributes' => [
+                    'left'   => ['align' => 'left'],
+                    'center' => ['align' => 'center'],
+                    'right'  => ['align' => 'right'],
+                ]
+            ]
+        ];
+        $environment = new Environment($config);
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new DisallowedRawHtmlExtension());
+        $environment->addExtension(new TableExtension());
         $converter = new MarkdownConverter($environment);
         $docBuilder = new DocumentationBuilder(
             $converter,

--- a/src/Documentation/Binders/DocumentationBinder.php
+++ b/src/Documentation/Binders/DocumentationBinder.php
@@ -22,7 +22,6 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
-use Parsedown;
 use ParsedownExtra;
 use PDO;
 
@@ -60,7 +59,7 @@ final class DocumentationBinder extends Binder
         );
         $container->bindInstance(FilesystemOperator::class, $files);
         $docBuilder = new DocumentationBuilder(
-            new Parsedown(new ParsedownExtra()),
+            new ParsedownExtra(),
             $metadata->branches,
             __DIR__ . '/../../../tmp/docs',
             '/tmp/docs',

--- a/src/Documentation/Binders/DocumentationBinder.php
+++ b/src/Documentation/Binders/DocumentationBinder.php
@@ -21,6 +21,8 @@ use App\Documentation\Searching\PostgreSqlSearchIndex;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\DisallowedRawHtml\DisallowedRawHtmlExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
 use League\CommonMark\MarkdownConverter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
@@ -61,6 +63,7 @@ final class DocumentationBinder extends Binder
             )
         );
         $container->bindInstance(FilesystemOperator::class, $files);
+
         $environment = new Environment();
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new DisallowedRawHtmlExtension());

--- a/src/Documentation/Binders/DocumentationBinder.php
+++ b/src/Documentation/Binders/DocumentationBinder.php
@@ -18,11 +18,14 @@ use App\Documentation\DocumentationBuilder;
 use App\Documentation\DocumentationIndexer;
 use App\Documentation\DocumentationMetadata;
 use App\Documentation\Searching\PostgreSqlSearchIndex;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\DisallowedRawHtml\DisallowedRawHtmlExtension;
+use League\CommonMark\MarkdownConverter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
-use ParsedownExtra;
 use PDO;
 
 /**
@@ -58,8 +61,12 @@ final class DocumentationBinder extends Binder
             )
         );
         $container->bindInstance(FilesystemOperator::class, $files);
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new DisallowedRawHtmlExtension());
+        $converter = new MarkdownConverter($environment);
         $docBuilder = new DocumentationBuilder(
-            new ParsedownExtra(),
+            $converter,
             $metadata->branches,
             __DIR__ . '/../../../tmp/docs',
             '/tmp/docs',

--- a/src/Documentation/DocumentationBuilder.php
+++ b/src/Documentation/DocumentationBuilder.php
@@ -15,7 +15,7 @@ namespace App\Documentation;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\StorageAttributes;
-use Parsedown;
+use ParsedownExtra;
 
 /**
  * Defines the documentation builder
@@ -26,7 +26,7 @@ final class DocumentationBuilder
     private const string GITHUB_REPOSITORY = 'https://github.com/aphiria/docs.git';
 
     /**
-     * @param Parsedown $markdownParser The Markdown parser
+     * @param ParsedownExtra $markdownParser The Markdown parser
      * @param list<string> $branches The branches to download
      * @param string $clonedDocAbsolutePath The absolute path to the cloned documentation
      * @param string $clonedDocRelativePath The relative path to the cloned documentation
@@ -34,7 +34,7 @@ final class DocumentationBuilder
      * @param FilesystemOperator $files The file system helper
      */
     public function __construct(
-        private readonly Parsedown $markdownParser,
+        private readonly ParsedownExtra $markdownParser,
         private readonly array $branches,
         private readonly string $clonedDocAbsolutePath,
         private readonly string $clonedDocRelativePath,
@@ -138,7 +138,7 @@ final class DocumentationBuilder
                 \shell_exec(
                     \sprintf(
                         'git clone -b %s --single-branch %s "%s"',
-                        $branch,
+                        'context', // TODO: CHANGE THIS BACK TO $branch BEFORE MERGING PR
                         self::GITHUB_REPOSITORY,
                         $this->clonedDocAbsolutePath . "/$branch"
                     )

--- a/src/Documentation/DocumentationBuilder.php
+++ b/src/Documentation/DocumentationBuilder.php
@@ -140,7 +140,7 @@ final class DocumentationBuilder
                 \shell_exec(
                     \sprintf(
                         'git clone -b %s --single-branch %s "%s"',
-                        'context', // TODO: CHANGE THIS BACK TO $branch BEFORE MERGING PR
+                        $branch,
                         self::GITHUB_REPOSITORY,
                         $this->clonedDocAbsolutePath . "/$branch"
                     )

--- a/src/Documentation/DocumentationIndexer.php
+++ b/src/Documentation/DocumentationIndexer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace App\Documentation;
 
+use App\Documentation\Searching\Context;
 use App\Documentation\Searching\IndexingFailedException;
 use App\Documentation\Searching\ISearchIndex;
 use App\Documentation\Searching\SearchResult;
@@ -81,10 +82,11 @@ final class DocumentationIndexer
      * Searches the documentation with a query
      *
      * @param string $query The raw search query
+     * @param Context $context The context to search under
      * @return list<SearchResult> The list of search results
      */
-    public function searchDocs(string $query): array
+    public function searchDocs(string $query, Context $context): array
     {
-        return $this->searchIndex->query($query);
+        return $this->searchIndex->query($query, $context);
     }
 }

--- a/src/Documentation/DocumentationModule.php
+++ b/src/Documentation/DocumentationModule.php
@@ -14,8 +14,10 @@ namespace App\Documentation;
 
 use Aphiria\Application\IApplicationBuilder;
 use Aphiria\Framework\Application\AphiriaModule;
+use Aphiria\Net\Http\HttpStatusCode;
 use App\Databases\Binders\SqlBinder;
 use App\Documentation\Binders\DocumentationBinder;
+use App\Documentation\Searching\InvalidContextException;
 
 /**
  * Defines the documentation module
@@ -27,9 +29,15 @@ final class DocumentationModule extends AphiriaModule
      */
     public function configure(IApplicationBuilder $appBuilder): void
     {
-        $this->withBinders($appBuilder, [
-            new SqlBinder(),
-            new DocumentationBinder()
-        ]);
+        $this
+            ->withBinders($appBuilder, [
+                new SqlBinder(),
+                new DocumentationBinder()
+            ])
+            ->withProblemDetails(
+                $appBuilder,
+                InvalidContextException::class,
+                status: HttpStatusCode::BadRequest
+            );
     }
 }

--- a/src/Documentation/Searching/Context.php
+++ b/src/Documentation/Searching/Context.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria.com/blob/master/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace App\Documentation\Searching;
+
+/**
+ * Defines the different context that you can search under
+ */
+enum Context: string
+{
+    case Framework = 'framework';
+    case Library = 'library';
+    case Global = 'global';
+}

--- a/src/Documentation/Searching/ISearchIndex.php
+++ b/src/Documentation/Searching/ISearchIndex.php
@@ -29,7 +29,8 @@ interface ISearchIndex
      * Queries the documentation and returns any matches
      *
      * @param string $query The raw search query
+     * @param Context $context The context to search under
      * @return list<SearchResult> The list of search results
      */
-    public function query(string $query): array;
+    public function query(string $query, Context $context): array;
 }

--- a/src/Documentation/Searching/IndexEntry.php
+++ b/src/Documentation/Searching/IndexEntry.php
@@ -18,10 +18,11 @@ namespace App\Documentation\Searching;
 final readonly class IndexEntry
 {
     /**
-     * @param string $htmlElementType The type of HTML element being index
-     * @param string $innerText The inner text of the HTML element being index
+     * @param string $htmlElementType The type of HTML element being indexed
+     * @param string $innerText The inner text of the HTML element being indexed
      * @param string $link The link that will take a user to this part of the documentation
      * @param string $htmlElementWeight The weight (eg 'A', 'B', 'C', or 'D') of the tag so we know how relevant it is
+     * @param Context $context The context that the entry applies to
      * @param string $h1InnerText The previous h1 sibling's inner text
      * @param string|null $h2InnerText The previous h2 sibling's inner text
      * @param string|null $h3InnerText The previous h3 sibling's inner text
@@ -33,6 +34,7 @@ final readonly class IndexEntry
         public string $innerText,
         public string $link,
         public string $htmlElementWeight,
+        public Context $context,
         public string $h1InnerText,
         public ?string $h2InnerText = null,
         public ?string $h3InnerText = null,

--- a/src/Documentation/Searching/InvalidContextException.php
+++ b/src/Documentation/Searching/InvalidContextException.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Aphiria
+ *
+ * @link      https://www.aphiria.com
+ * @copyright Copyright (C) 2025 David Young
+ * @license   https://github.com/aphiria/aphiria.com/blob/master/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace App\Documentation\Searching;
+
+use Exception;
+
+/**
+ * Defines the exception that's thrown when the context is invalid
+ */
+final class InvalidContextException extends Exception {}

--- a/src/Documentation/Searching/PostgreSqlSearchIndex.php
+++ b/src/Documentation/Searching/PostgreSqlSearchIndex.php
@@ -37,6 +37,7 @@ final class PostgreSqlSearchIndex implements ISearchIndex
         'h4' => 'D',
         'h5' => 'D',
         'p' => 'D',
+        'div' => 'D',
         'li' => 'D',
         'blockquote' => 'D'
     ];
@@ -381,7 +382,7 @@ EOF
                 }
             }
 
-            $node = $node->parentNode;
+            $node = $node->parentElement;
         }
 
         return Context::Global;

--- a/src/Documentation/Searching/PostgreSqlSearchIndex.php
+++ b/src/Documentation/Searching/PostgreSqlSearchIndex.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace App\Documentation\Searching;
 
 use DOMDocument;
+use DOMElement;
 use DOMNode;
 use Exception;
 use League\Flysystem\FilesystemOperator;
@@ -110,24 +111,21 @@ final class PostgreSqlSearchIndex implements ISearchIndex
                     // Only index specific elements
                     if (isset(self::$htmlElementsToWeights[$currNode->nodeName])) {
                         $filename = \basename($htmlPath);
-                        $indexEntries[] = $this->createIndexEntry($filename, $currNode, $h1, $h2, $h3, $h4, $h5);
+                        $indexEntries[] = $this->createIndexEntry($filename, $currNode, $this->getContext($currNode), $h1, $h2, $h3, $h4, $h5);
                     }
                 }
             }
 
             $this->createAndSeedTable($indexEntries);
         } catch (Throwable $ex) {
-            throw new IndexingFailedException('Failed to index document', 0, $ex);
+            throw new IndexingFailedException('Failed to index document: ' . $ex->getMessage(), 0, $ex);
         }
     }
 
     /**
-     * Queries the documentation and returns any matches
-     *
-     * @param string $query The raw search query
-     * @return list<SearchResult> The list of search results
+     * @inheritdoc
      */
-    public function query(string $query): array
+    public function query(string $query, Context $context): array
     {
         /**
          * This query is doing two things - using natural English language processing to match on prefixes of words, eg
@@ -148,14 +146,14 @@ SELECT DISTINCT ON(rank, link, html_element_type) link, html_element_type, rank,
 ((SELECT link, html_element_type, rank, ts_headline('english', h1_inner_text, query, '{$tsHeadlineOptions}') as h1_highlights, ts_headline('english', h2_inner_text, query, '{$tsHeadlineOptions}') as h2_highlights, ts_headline('english', h3_inner_text, query, '{$tsHeadlineOptions}') as h3_highlights, ts_headline('english', h4_inner_text, query, '{$tsHeadlineOptions}') as h4_highlights, ts_headline('english', h5_inner_text, query, '{$tsHeadlineOptions}') as h5_highlights, ts_headline('english', inner_text, query, '{$tsHeadlineOptions}') as inner_text_highlights
 FROM (SELECT link, html_element_type, h1_inner_text, h2_inner_text, h3_inner_text, h4_inner_text, h5_inner_text, inner_text, ts_rank_cd(english_lexemes, query) AS rank, query
         FROM {$tableName}, plainto_tsquery('english', :query) AS query
-        WHERE english_lexemes @@ query
+        WHERE english_lexemes @@ query AND (context = :context OR context = 'global')
         ORDER BY rank DESC
         LIMIT :maxResults) AS english_matching_query)
 UNION
 (SELECT link, html_element_type, rank, ts_headline(h1_inner_text, query, '{$tsHeadlineOptions}') as h1_highlights, ts_headline(h2_inner_text, query, '{$tsHeadlineOptions}') as h2_highlights, ts_headline(h3_inner_text, query, '{$tsHeadlineOptions}') as h3_highlights, ts_headline(h4_inner_text, query, '{$tsHeadlineOptions}') as h4_highlights, ts_headline(h5_inner_text, query, '{$tsHeadlineOptions}') as h5_highlights, ts_headline(inner_text, query, '{$tsHeadlineOptions}') as inner_text_highlights
     FROM (SELECT link, html_element_type, h1_inner_text, h2_inner_text, h3_inner_text, h4_inner_text, h5_inner_text, inner_text, ts_rank_cd(simple_lexemes, query) AS rank, query
           FROM {$tableName}, (SELECT (SELECT (array_to_string(string_to_array(:query, ' '), ':* & ') || ':*'))::tsquery AS query) AS query
-          WHERE simple_lexemes @@ query
+          WHERE simple_lexemes @@ query AND (context = :context OR context = 'global')
           ORDER BY rank DESC
           LIMIT :maxResults) AS non_english_matching_query)) AS distinct_query
 ORDER BY rank DESC
@@ -165,6 +163,7 @@ EOF
         // The query must be lower cased for our full text search to work appropriately
         $statement->execute([
             'query' => \mb_strtolower(\trim($query)),
+            'context' => $context->value,
             'maxResults' => self::MAX_NUM_SEARCH_RESULTS
         ]);
         $searchResults = [];
@@ -215,6 +214,7 @@ EOF
      *
      * @param string $filename The filename of the doc being indexed
      * @param DOMNode $currNode The current node
+     * @param Context $context The context the entry is in
      * @param DOMNode $h1 The current H1 node
      * @param DOMNode|null $h2 The current H2 node
      * @param DOMNode|null $h3 The current H3 node
@@ -226,6 +226,7 @@ EOF
     private function createIndexEntry(
         string $filename,
         DOMNode $currNode,
+        Context $context,
         DOMNode $h1,
         ?DOMNode $h2,
         ?DOMNode $h3,
@@ -261,6 +262,7 @@ EOF
             $this->getAllChildNodeTexts($currNode),
             $link,
             self::$htmlElementsToWeights[$currNode->nodeName],
+            $context,
             $this->getAllChildNodeTexts($h1),
             $h2 === null ? null : $this->getAllChildNodeTexts($h2),
             $h3 === null ? null : $this->getAllChildNodeTexts($h3),
@@ -284,6 +286,7 @@ CREATE TABLE IF NOT EXISTS {$tableName} (
     h3_inner_text TEXT,
     h4_inner_text TEXT,
     h5_inner_text TEXT,
+    context TEXT NOT NULL,
     link TEXT NOT NULL,
     html_element_type TEXT NOT NULL,
     inner_text TEXT NOT NULL,
@@ -311,6 +314,12 @@ EOF
         $statement = $this->pdo->prepare(
             <<<EOF
 CREATE INDEX {$tableName}_simple_lexeme_idx ON {$tableName} USING gin(simple_lexemes)
+EOF
+        );
+        $statement->execute();
+        $statement = $this->pdo->prepare(
+            <<<EOF
+CREATE INDEX {$tableName}_context ON {$tableName}(context)
 EOF
         );
         $statement->execute();
@@ -352,6 +361,33 @@ EOF
     }
 
     /**
+     * Gets the context for a node
+     *
+     * @param DOMNode $node The node whose context we want
+     * @return Context The current context
+     */
+    private function getContext(DOMNode $node): Context
+    {
+        while ($node !== null) {
+            if ($node instanceof DOMElement && $node->hasAttribute('class')) {
+                $classes = \explode(' ', $node->getAttribute('class'));
+
+                if (\in_array('context-framework', $classes, true)) {
+                    return Context::Framework;
+                }
+
+                if (\in_array('context-library', $classes, true)) {
+                    return Context::Library;
+                }
+            }
+
+            $node = $node->parentNode;
+        }
+
+        return Context::Global;
+    }
+
+    /**
      * Inserts an index entry into the database
      *
      * @param IndexEntry $indexEntry The entry to insert
@@ -361,8 +397,8 @@ EOF
         $tableName = self::TABLE_NAME;
         $statement = $this->pdo->prepare(
             <<<EOF
-INSERT INTO {$tableName} (h1_inner_text, h2_inner_text, h3_inner_text, h4_inner_text, h5_inner_text, link, html_element_type, inner_text, html_element_weight)
-VALUES (:h1InnerText, :h2InnerText, :h3InnerText, :h4InnerText, :h5InnerText, :link, :htmlElementType, :innerText, :htmlElementWeight)
+INSERT INTO {$tableName} (h1_inner_text, h2_inner_text, h3_inner_text, h4_inner_text, h5_inner_text, link, html_element_type, inner_text, html_element_weight, context)
+VALUES (:h1InnerText, :h2InnerText, :h3InnerText, :h4InnerText, :h5InnerText, :link, :htmlElementType, :innerText, :htmlElementWeight, :context)
 EOF
         );
         $statement->execute([
@@ -374,7 +410,8 @@ EOF
             'link' => $indexEntry->link,
             'htmlElementType' => $indexEntry->htmlElementType,
             'innerText' => $indexEntry->innerText,
-            'htmlElementWeight' => $indexEntry->htmlElementWeight
+            'htmlElementWeight' => $indexEntry->htmlElementWeight,
+            'context' => $indexEntry->context->value
         ]);
     }
 

--- a/tests/Integration/Documentation/DocumentationTest.php
+++ b/tests/Integration/Documentation/DocumentationTest.php
@@ -36,6 +36,8 @@ class DocumentationTest extends IntegrationTestCase
              * @return bool
              */
             static function (array $results): bool {
+                echo \var_export($results, true);ob_flush();
+
                 return \count($results) > 0 && \str_contains($results[0]->highlightedH1, 'Routing');
             }
         );

--- a/tests/Integration/Documentation/DocumentationTest.php
+++ b/tests/Integration/Documentation/DocumentationTest.php
@@ -12,14 +12,22 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Documentation;
 
+use Aphiria\Net\Http\HttpStatusCode;
 use App\Documentation\Searching\SearchResult;
 use App\Tests\Integration\IntegrationTestCase;
 
 class DocumentationTest extends IntegrationTestCase
 {
+    public function testSearchingForItemWithBadContextReturns400(): void
+    {
+        $response = $this->get('/docs/search?query=routing', ['Cookie' => 'context=invalid']);
+        $this->assertStatusCodeEquals(HttpStatusCode::BadRequest, $response);
+    }
+
     public function testSearchingForItemWithDocumentationReturnsResults(): void
     {
         $response = $this->get('/docs/search?query=routing');
+        $this->assertStatusCodeEquals(HttpStatusCode::Ok, $response);
         $this->assertParsedBodyPassesCallback(
             $response,
             SearchResult::class . '[]',
@@ -36,6 +44,7 @@ class DocumentationTest extends IntegrationTestCase
     public function testSearchingForNonExistentTermReturnsEmptyResults(): void
     {
         $response = $this->get('/docs/search?query=abcdefghijklmnopqrstuvwxyz');
+        $this->assertStatusCodeEquals(HttpStatusCode::Ok, $response);
         // The Symfony serializer cannot deserialize type 'array', so we cannot just check if it equals []
         $this->assertParsedBodyPassesCallback(
             $response,

--- a/tests/Integration/Documentation/DocumentationTest.php
+++ b/tests/Integration/Documentation/DocumentationTest.php
@@ -36,8 +36,6 @@ class DocumentationTest extends IntegrationTestCase
              * @return bool
              */
             static function (array $results): bool {
-                echo \var_export($results, true);ob_flush();
-
                 return \count($results) > 0 && \str_contains($results[0]->highlightedH1, 'Routing');
             }
         );


### PR DESCRIPTION
- [x] Figure out how to handle doc context when doing a search.  Do we need to add that to the DB (possibly seeing if we're inside an element with a context CSS class and, if so, storing that alongside the result + appending it to the search query string)
- [ ] If I'm going to use the CommonMark library's table of contents feature, I need a way of knowing if what I'm linking to happens to be in a `content-framework` or `content-library` classed element and, if so, apply that same class to the URL.  Likely requires some customization of the library.